### PR TITLE
Allow ignoring unused imports in require comments

### DIFF
--- a/modfile/rule_test.go
+++ b/modfile/rule_test.go
@@ -177,8 +177,8 @@ var setRequireTests = []struct {
 			x.y/c v1.2.3 // indirect; c
 			x.y/d v1.2.3 // indirect; c
 			x.y/e v1.2.3 // indirect
-			x.y/f v1.2.3 //indirect
-			x.y/g v1.2.3 //	indirect
+			x.y/f v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
 		)
 		`,
 	},
@@ -334,8 +334,8 @@ var setRequireSeparateIndirectTests = []struct {
 			x.y/c v1.2.3 // indirect; c
 			x.y/d v1.2.3 // indirect; c
 			x.y/e v1.2.3 // indirect
-			x.y/f v1.2.3 //indirect
-			x.y/g v1.2.3 //	indirect
+			x.y/f v1.2.3 // indirect
+			x.y/g v1.2.3 // indirect
 		)
 		`,
 	},


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/51262

This change modifies Go to allow ignore unused imports in `go.mod` files. Given that this change introduces a second type of a parseable comment, in addition to `indirect`, there's a refactor to use `tokens` map for both kinds of comments.

If accepted, I'll follow up with a matching change in https://github.com/golang/tools